### PR TITLE
add --force parameter to awsrm for use in automation

### DIFF
--- a/handle_args.go
+++ b/handle_args.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func handleInputFromArgs(ctx context.Context, args []string, profile, region string, dryRun bool) int {
+func handleInputFromArgs(ctx context.Context, args []string, profile, region string, force bool, dryRun bool) int {
 	log.Debug("input via args")
 
 	rType := resource.PrefixResourceType(args[0])
@@ -89,7 +89,7 @@ func handleInputFromArgs(ctx context.Context, args []string, profile, region str
 	}
 
 	doneDelete := make(chan bool, 1)
-	go func() { resource.Delete(resources, os.Stdin, dryRun, doneDelete) }()
+	go func() { resource.Delete(resources, os.Stdin, force, dryRun, doneDelete) }()
 	select {
 	case <-ctx.Done():
 		return 0

--- a/handle_pipe.go
+++ b/handle_pipe.go
@@ -19,7 +19,7 @@ func isInputFromPipe() bool {
 	return fileInfo.Mode()&os.ModeNamedPipe != 0
 }
 
-func handleInputFromPipe(ctx context.Context, dryRun bool) int {
+func handleInputFromPipe(ctx context.Context, force bool, dryRun bool) int {
 	log.Debug("input via pipe")
 
 	resources, err := resource.Read(os.Stdin)
@@ -72,7 +72,7 @@ func handleInputFromPipe(ctx context.Context, dryRun bool) int {
 
 	doneDelete := make(chan bool, 1)
 	go func() {
-		resource.Delete(resources, confirmDevice, dryRun, doneDelete)
+		resource.Delete(resources, confirmDevice, force, dryRun, doneDelete)
 	}()
 	select {
 	case <-ctx.Done():

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func mainExitCode() int {
 	}
 
 	flags.BoolVar(&logDebug, "debug", false, "Enable debug logging")
-	flags.BoolVar(&force, "force", false, "Bypassess the confirmation prompt. Use with caution!")
+	flags.BoolVar(&force, "force", false, "Delete without asking for confirmation. Use with caution!")
 	flags.BoolVar(&dryRun, "dry-run", false, "Don't delete anything, just show what would be deleted")
 	flags.StringVarP(&profile, "profile", "p", "", "The AWS profile for the account to delete resources in")
 	flags.StringVarP(&region, "region", "r", "", "The region to delete resources in")

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func mainExitCode() int {
 	var version bool
 	var profile string
 	var region string
+	var force bool
 	var dryRun bool
 
 	flags := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
@@ -36,6 +37,7 @@ func mainExitCode() int {
 	}
 
 	flags.BoolVar(&logDebug, "debug", false, "Enable debug logging")
+	flags.BoolVar(&force, "force", false, "Bypassess the confirmation prompt. Use with caution!")
 	flags.BoolVar(&dryRun, "dry-run", false, "Don't delete anything, just show what would be deleted")
 	flags.StringVarP(&profile, "profile", "p", "", "The AWS profile for the account to delete resources in")
 	flags.StringVarP(&region, "region", "r", "", "The region to delete resources in")
@@ -83,7 +85,7 @@ func mainExitCode() int {
 	}()
 
 	if isInputFromPipe() {
-		return handleInputFromPipe(ctx, dryRun)
+		return handleInputFromPipe(ctx, force, dryRun)
 	}
 
 	if len(args) < 2 {
@@ -91,7 +93,7 @@ func mainExitCode() int {
 		return 1
 	}
 
-	return handleInputFromArgs(ctx, args, profile, region, dryRun)
+	return handleInputFromArgs(ctx, args, profile, region, force, dryRun)
 }
 
 func printHelp(fs *flag.FlagSet) {

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -51,7 +51,7 @@ func Update(resources []terraform.Resource, providers map[aws.ClientKey]provider
 }
 
 // Delete deletes the given resources via the Terraform AWS Provider.
-func Delete(resources []terraform.Resource, confirmDevice io.Reader, dryRun bool, done chan bool) {
+func Delete(resources []terraform.Resource, confirmDevice io.Reader, force bool, dryRun bool, done chan bool) {
 	if len(resources) == 0 {
 		internal.LogTitle("no resources found to delete")
 		done <- true
@@ -75,9 +75,13 @@ func Delete(resources []terraform.Resource, confirmDevice io.Reader, dryRun bool
 	internal.LogTitle(fmt.Sprintf("total number of resources that would be deleted: %d", len(resources)))
 
 	if !dryRun && len(resources) > 0 {
-		if !internal.UserConfirmedDeletion(confirmDevice) {
-			done <- true
-			return
+		if !force {
+			if !internal.UserConfirmedDeletion(confirmDevice) {
+				done <- true
+				return
+			}
+		} else {
+			internal.LogTitle("Proceeding with deletion and skipping confirmation (Force)")
 		}
 
 		internal.LogTitle("Starting to delete resources")

--- a/test/args_test.go
+++ b/test/args_test.go
@@ -93,6 +93,19 @@ func TestAcc_Args_UserConfirmation(t *testing.T) {
 			expectedLogs: []string{
 				"PROCEEDING WITH DELETION AND SKIPPING CONFIRMATION (FORCE)",
 				"TOTAL NUMBER OF RESOURCES THAT WOULD BE DELETED: 1",
+				"TOTAL NUMBER OF DELETED RESOURCES: 1",
+			},
+			unexpectedLogs: []string{
+				"STARTING TO DELETE RESOURCES",
+				"Are you sure you want to delete these resources (cannot be undone)? Only YES will be accepted.",
+			},
+		},
+		{
+			name:      "force and dry run",
+			extraArgs: []string{"--force --dry-run"},
+			expectedLogs: []string{
+				"SHOWING RESOURCES THAT WOULD BE DELETED (DRY RUN)",
+				"TOTAL NUMBER OF RESOURCES THAT WOULD BE DELETED: 1",
 			},
 			unexpectedLogs: []string{
 				"STARTING TO DELETE RESOURCES",

--- a/test/args_test.go
+++ b/test/args_test.go
@@ -87,6 +87,19 @@ func TestAcc_Args_UserConfirmation(t *testing.T) {
 				"Are you sure you want to delete these resources (cannot be undone)? Only YES will be accepted.",
 			},
 		},
+		{
+			name:      "force",
+			extraArgs: []string{"--force"},
+			expectedLogs: []string{
+				"PROCEEDING WITH DELETION AND SKIPPING CONFIRMATION (FORCE)",
+				"TOTAL NUMBER OF RESOURCES THAT WOULD BE DELETED: 1",
+			},
+			unexpectedLogs: []string{
+				"STARTING TO DELETE RESOURCES",
+				"TOTAL NUMBER OF DELETED RESOURCES:",
+				"Are you sure you want to delete these resources (cannot be undone)? Only YES will be accepted.",
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/pipe_test.go
+++ b/test/pipe_test.go
@@ -52,14 +52,15 @@ func TestAcc_Pipe_InputFromAwsls(t *testing.T) {
 	AssertVpcExists(t, vpc4, testVars.AWSProfile2, testVars.AWSRegion2)
 
 	tests := []struct {
-		name            string
-		awslsArgs       []string
-		grepArgs        []string
-		awsrmArgs       []string
-		envs            map[string]string
-		expectedLogs    []string
-		unexpectedLogs  []string
-		expectedErrCode int
+		name                    string
+		awslsArgs               []string
+		grepArgs                []string
+		awsrmArgs               []string
+		envs                    map[string]string
+		expectResourceIsDeleted bool
+		expectedLogs            []string
+		unexpectedLogs          []string
+		expectedErrCode         int
 	}{
 		{
 			name: "single resource",
@@ -67,8 +68,9 @@ func TestAcc_Pipe_InputFromAwsls(t *testing.T) {
 				"-p", testVars.AWSProfile1,
 				"-r", testVars.AWSRegion1,
 				"-a", "tags", "aws_vpc"},
-			grepArgs:  []string{"foo"},
-			awsrmArgs: []string{"--dry-run"},
+			grepArgs:                []string{"foo"},
+			awsrmArgs:               []string{"--dry-run"},
+			expectResourceIsDeleted: false,
 			expectedLogs: []string{
 				"SHOWING RESOURCES THAT WOULD BE DELETED \\(DRY RUN\\)",
 				"TOTAL NUMBER OF RESOURCES THAT WOULD BE DELETED: 1",
@@ -86,8 +88,9 @@ func TestAcc_Pipe_InputFromAwsls(t *testing.T) {
 				"-p", fmt.Sprintf("%s,%s", testVars.AWSProfile1, testVars.AWSProfile2),
 				"-r", fmt.Sprintf("%s,%s", testVars.AWSRegion1, testVars.AWSRegion2),
 				"-a", "tags", "aws_vpc"},
-			grepArgs:  []string{"awsrm=test-acc"},
-			awsrmArgs: []string{"--dry-run"},
+			grepArgs:                []string{"awsrm=test-acc"},
+			awsrmArgs:               []string{"--dry-run"},
+			expectResourceIsDeleted: false,
 			expectedLogs: []string{
 				"SHOWING RESOURCES THAT WOULD BE DELETED \\(DRY RUN\\)",
 				"TOTAL NUMBER OF RESOURCES THAT WOULD BE DELETED: 4",
@@ -106,22 +109,22 @@ func TestAcc_Pipe_InputFromAwsls(t *testing.T) {
 			},
 		},
 		{
-			name: "single resource with force",
+			name: "force flag",
 			awslsArgs: []string{
 				"-p", testVars.AWSProfile1,
 				"-r", testVars.AWSRegion1,
 				"-a", "tags", "aws_vpc"},
-			grepArgs:  []string{"foo"},
-			awsrmArgs: []string{"--force"},
+			grepArgs:                []string{"foo"},
+			awsrmArgs:               []string{"--force"},
+			expectResourceIsDeleted: true,
 			expectedLogs: []string{
-				"PROCEEDING WITH DELETION AND SKIPPING CONFIRMATION \\(FORCE\\)",
+				"PROCEEDING WITH DELETION AND SKIPPING CONFIRMATION (FORCE)",
 				"TOTAL NUMBER OF RESOURCES THAT WOULD BE DELETED: 1",
 				fmt.Sprintf("aws_vpc\\s+id=%s\\s+profile=%s\\s+region=%s",
 					vpc1, testVars.AWSProfile1, testVars.AWSRegion1),
 			},
 			unexpectedLogs: []string{
-				"STARTING TO DELETE RESOURCES",
-				"TOTAL NUMBER OF DELETED RESOURCES:",
+				"Are you sure you want to delete these resources (cannot be undone)? Only YES will be accepted.",
 			},
 		},
 	}

--- a/test/pipe_test.go
+++ b/test/pipe_test.go
@@ -105,6 +105,25 @@ func TestAcc_Pipe_InputFromAwsls(t *testing.T) {
 				"TOTAL NUMBER OF DELETED RESOURCES:",
 			},
 		},
+		{
+			name: "single resource with force",
+			awslsArgs: []string{
+				"-p", testVars.AWSProfile1,
+				"-r", testVars.AWSRegion1,
+				"-a", "tags", "aws_vpc"},
+			grepArgs:  []string{"foo"},
+			awsrmArgs: []string{"--force"},
+			expectedLogs: []string{
+				"PROCEEDING WITH DELETION AND SKIPPING CONFIRMATION \\(FORCE\\)",
+				"TOTAL NUMBER OF RESOURCES THAT WOULD BE DELETED: 1",
+				fmt.Sprintf("aws_vpc\\s+id=%s\\s+profile=%s\\s+region=%s",
+					vpc1, testVars.AWSProfile1, testVars.AWSRegion1),
+			},
+			unexpectedLogs: []string{
+				"STARTING TO DELETE RESOURCES",
+				"TOTAL NUMBER OF DELETED RESOURCES:",
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This PR adds a `--force` parameter to `awsrm` to prevent the confirmation dialogue from showing in the tool when performing a deletion of resources. This enables the use of `awsrm` in automation, or to quickly by-pass confirmation if you have already run a `--dry-run`. 

Please use with caution!

This is also my very first OSS contribution that is actual code, so pretty excited!

I didn't have time to navigate/update the test fixtures (could use some documentation there), so I wasn't able to run the acceptance tests, but I've added the cases. I did however test this manually by creating an S3 bucket, and then proceeding to delete it.

```
$ awsls s3_bucket -r us-east-2 -a tags | grep name=christ-test-delete-me | ./awsrm --force

   • SHOWING RESOURCES THAT WOULD BE DELETED (DRY RUN)
      • aws_s3_bucket                            id=christ-test-delete-me profile=N/A region=us-east-2
   • TOTAL NUMBER OF RESOURCES THAT WOULD BE DELETED: 1
   • PROCEEDING WITH DELETION AND SKIPPING CONFIRMATION (FORCE)
   • STARTING TO DELETE RESOURCES
      ⨯ aws_s3_bucket                                      id=christ-test-delete-me
   • TOTAL NUMBER OF DELETED RESOURCES: 1
```